### PR TITLE
Update API folder to lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-const bin = require('./bin');
+const bin = require('./lib');
 module.exports = bin;


### PR DESCRIPTION
Repoint the package to lib instead of bin. Installing the package currently doesn't work because ./bin doesn't exist.