### PR TITLE
docs: fix .image usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pdfDoc
     .text('Add some texts to an existing pdf file', 150, 300)
     .rectangle(20, 20, 40, 100)
     .comment('Add 1st comment annotaion', 200, 300)
-    .image('/path/to/image.jpg', {width: 300, keepAspectRatio: true})
+    .image('/path/to/image.jpg', 20, 100, {width: 300, keepAspectRatio: true})
     .endPage()
     // edit 2nd page
     .editPage(2)


### PR DESCRIPTION
As i follow the guide in `Modify an existing PDF`
Will Receive an error message:
`TypeError: Wrong Arguments, please provide 6 arguments forming a 2d transformation matrix`
So i fixed the doc example.