### PR TITLE
Fix for #80, failed color application to rotated text

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -18,9 +18,9 @@ const xObjectForm = require('./xObjectForm');
  * @param {number} x - The coordinate x
  * @param {number} y - The coordinate y
  * @param {Object} [options] - The options
- * @param {string|number[]} [options.color] - HexColor or RGB
+ * @param {string|number[]} [options.color] - HexColor (#000000 to #ffffff) or RGB (0 to 255)
  * @param {number} [options.opacity] - opacity
- * @param {number} [options.rotation] - Currently only accept: +/- 0/90/180/270. Default: 0
+ * @param {number} [options.rotation] - Accept: +/- 0 through 360. Default: 0
  * @param {number[]} [options.rotationOrigin] - [originX, originY] Default: the text coordinate
  * @param {string} [options.font] - The font. 'Arial', 'Helvetica'...
  * @param {number} [options.size] - The line width

--- a/lib/vector.helper.js
+++ b/lib/vector.helper.js
@@ -112,7 +112,7 @@ exports._createExtGStates = function _createExtGStates(value) {
 exports._transformColor = transformColor;
 
 function transformColorToRGB(code) {
-    return (Array.isArray(code)) ? code : hexToRgb(code);
+    return (Array.isArray(code)) ? { r:code[0]/255, g:code[1]/255, b:code[2]/255 } : hexToRgb(code);
 }
 
 function transformColor(code = '') {
@@ -144,9 +144,9 @@ function rgbToHexCode(rgb = []) {
 function hexToRgb(hex) {
     var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result ? {
-        r: parseInt(result[1], 16),
-        g: parseInt(result[2], 16),
-        b: parseInt(result[3], 16)
+        r: parseInt(result[1], 16)/255,
+        g: parseInt(result[2], 16)/255,
+        b: parseInt(result[3], 16)/255
     } : null;
 }
 


### PR DESCRIPTION
Text color is appropriately applied to rotated text.