### PR TITLE
update 1.8.5

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -30,7 +30,7 @@ class Recipe {
         } else {
             this.output = output || src;
             if (this.src) {
-                this.filename = this.src.split('/').pop();
+                this.filename = path.basename(this.src);
             }
         }
         this.hummus = hummus;

--- a/lib/appendPage.js
+++ b/lib/appendPage.js
@@ -1,4 +1,5 @@
 const hummus = require('hummus');
+const hummusUtils = require('./utils');
 
 /**
  * Append pages from the other pdf to the current pdf
@@ -34,12 +35,11 @@ exports.appendPage = function appendPage(pdfSrc, pages = []) {
         }
     });
     if (pages.length > 0) {
-        this.writer.appendPDFPagesFromPDF(pdfSrc, {
-            type: hummus.eRangeTypeSpecific,
+        hummusUtils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc, {
             specificRanges: pages
         });
     } else {
-        this.writer.appendPDFPagesFromPDF(pdfSrc);
+        hummusUtils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc);
     }
     return this;
 };

--- a/lib/insertPage.js
+++ b/lib/insertPage.js
@@ -1,5 +1,6 @@
 const hummus = require('hummus');
 const fs = require('fs');
+const hummusUtils = require('./utils');
 /**
  * Insert a page from the other pdf
  * @name insertPage
@@ -47,8 +48,7 @@ exports._insertPages = function _insertPages() {
             const specificRanges = [
                 [lastInsertedOriginal, toAppendPage]
             ];
-            pdfWriter.appendPDFPagesFromPDF(tmp, {
-                type: hummus.eRangeTypeSpecific,
+            hummusUtils.appendPDFPagesFromPDFWithAnnotations(pdfWriter, tmp, {
                 specificRanges
             });
         }
@@ -60,19 +60,18 @@ exports._insertPages = function _insertPages() {
                 const specificRanges = [
                     [info.srcPageNumber - 1, info.srcPageNumber - 1]
                 ];
-                pdfWriter.appendPDFPagesFromPDF(info.pdfSrc, {
-                    type: hummus.eRangeTypeSpecific,
-                    specificRanges
-                });
+                hummusUtils.appendPDFPagesFromPDFWithAnnotations(pdfWriter, info.pdfSrc, { specificRanges });
             });
         }
     });
     pdfWriter.end();
 
     unlinkList.forEach((item) => {
-        if (fs.existsSync(item)) {
-            fs.unlinkSync(item);
-        }
+        setTimeout(() => {
+            if (fs.existsSync(item)) {
+                fs.unlinkSync(item);
+            }
+        });
     });
     return this;
 };

--- a/lib/split.js
+++ b/lib/split.js
@@ -1,5 +1,6 @@
 const hummus = require('hummus');
 const path = require('path');
+const hummusUtils = require('./utils');
 
 /**
  * Split the pdf
@@ -14,7 +15,7 @@ exports.split = function split(outputDir = '', prefix) {
     for (let i = 0; i < this.metadata.pages; i++) {
         const newPdf = path.join(outputDir, `${prefix}-${i+1}.pdf`);
         const pdfWriter = hummus.createWriter(newPdf);
-        pdfWriter.createPDFCopyingContext(this.pdfReader).appendPDFPageFromPDF(i);
+        hummusUtils.appendPDFPageFromPDFWithAnnotations(pdfWriter, this.pdfReader, i);
         pdfWriter.end();
     }
     return this;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,59 @@
+const ANNOTATION_PREFIX = 'Annots';
+
+/**
+ * Append PDF Page with annotations.
+ *
+ * @param {any} pdfWriter - Hummus writer.
+ * @param {string|any} sourcePDFPath - The path for the output pdfs or Reader stream.
+ * @param {number} pageNumber - page number.
+ * @param {any} [options={}] - appendPDFPageFromPDF options
+ */
+function appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, pageNumber) {
+    const cpyCxt = pdfWriter.createPDFCopyingContext(sourcePDFPath);
+    const cpyCxtParser = cpyCxt.getSourceDocumentParser();
+    const pageDictionary = cpyCxtParser.parsePageDictionary(pageNumber);
+
+    if (!pageDictionary.exists(ANNOTATION_PREFIX)) {
+        cpyCxt.appendPDFPageFromPDF(pageNumber);
+    } else {
+        let reffedObjects;
+        pdfWriter.getEvents().once('OnPageWrite', params => {
+            params.pageDictionaryContext.writeKey(ANNOTATION_PREFIX);
+            reffedObjects = cpyCxt.copyDirectObjectWithDeepCopy(pageDictionary.queryObject(ANNOTATION_PREFIX));
+        });
+
+        cpyCxt.appendPDFPageFromPDF(pageNumber);
+
+        if (reffedObjects && reffedObjects.length > 0) {
+            cpyCxt.copyNewObjectsForDirectObject(reffedObjects);
+        }
+    }
+}
+
+/**
+ * Append PDF Pages with annotations.
+ *
+ * @param {any} pdfWriter - Hummus writer.
+ * @param {string|any} sourcePDFPath - The path for the output pdfs or Reader stream.
+ * @param {any} [options={}] - appendPDFPagesFromPDF options
+ */
+function appendPDFPagesFromPDFWithAnnotations(pdfWriter, sourcePDFPath, options = {}) {
+    const cpyCxt = pdfWriter.createPDFCopyingContext(sourcePDFPath);
+    const cpyCxtParser = cpyCxt.getSourceDocumentParser();
+
+    if (options.specificRanges && options.specificRanges.length) {
+        for (const [start, end] of options.specificRanges) {
+            for (let i = start; i <= end; ++i) {
+                appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, i);
+            }
+        }
+    } else {
+        for (let i = 0; i < cpyCxtParser.getPagesCount(); ++i) {
+            appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, i);
+        }
+    }
+}
+
+exports.ANNOTATION_PREFIX = ANNOTATION_PREFIX;
+exports.appendPDFPageFromPDFWithAnnotations = appendPDFPageFromPDFWithAnnotations;
+exports.appendPDFPagesFromPDFWithAnnotations = appendPDFPagesFromPDFWithAnnotations;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hummus-recipe",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1094,9 +1094,9 @@
       "dev": true
     },
     "hummus": {
-      "version": "1.0.95",
-      "resolved": "https://registry.npmjs.org/hummus/-/hummus-1.0.95.tgz",
-      "integrity": "sha512-nDsVD7YlSIf1mKm7Is7F2huQOAwAste16xXdkeIv9z23OTIJIJObXVKET9viJn0fFzWEfqNHJxWooFo9H0yhGA==",
+      "version": "1.0.99",
+      "resolved": "https://registry.npmjs.org/hummus/-/hummus-1.0.99.tgz",
+      "integrity": "sha512-tlBi+wLJelj/X7OTjuSmE54pY8gciTFuUk6n6hbehDXyfCXnhtiMZgJfTkbF0EOWVsBKexAgObfR9yrcW/uJOg==",
       "requires": {
         "node-pre-gyp": "^0.10.0"
       },
@@ -1134,7 +1134,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true
         },
         "code-point-at": {
@@ -1198,7 +1198,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1214,7 +1214,7 @@
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -1266,7 +1266,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.4",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -1274,7 +1274,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -1292,7 +1292,7 @@
           "bundled": true
         },
         "needle": {
-          "version": "2.2.2",
+          "version": "2.2.4",
           "bundled": true,
           "requires": {
             "debug": "^2.1.2",
@@ -1335,7 +1335,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.11",
+          "version": "1.1.12",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -1436,7 +1436,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true
         },
         "set-blocking": {
@@ -1475,13 +1475,13 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.6",
+          "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
@@ -1503,7 +1503,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hummus-recipe",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "A powerful PDF tool for NodeJS based on HummusJS",
   "author": "John Huang <little78926@gmail.com>",
   "license": "MIT",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/chunyenHuang/hummusRecipe#readme",
   "dependencies": {
-    "hummus": "^1.0.95",
+    "hummus": "^1.0.99",
     "linebreak": "^0.3.0",
     "memory-streams": "^0.1.3",
     "static-eval": "^2.0.0",


### PR DESCRIPTION
- copy annotations on insert, split and append pages

@chunyenHuang Hi, I've copied annotations (especially for URL links) for split, insert and append functions. Could you please check this pull request? I suspect it will fix this issue #77. 