### PR TITLE
Fix issue where outStream is not written unless there is a callback

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -237,10 +237,13 @@ class Recipe {
             }
         }
 
+        if (this.isBufferSrc && this.output) {
+            fs.writeFileSync(this.output, this.outStream.toBuffer());
+        }
+
         if (callback) {
             if (this.isBufferSrc) {
                 if (this.output) {
-                    fs.writeFileSync(this.output, this.outStream.toBuffer());
                     return callback(this.output);
                 } else {
                     return callback(this.outStream.toBuffer());


### PR DESCRIPTION
Currently if no callback is passed into the constructor it will not write the file, even if there is an output argument passed in. This fixes that.