### PR TITLE
docs(readme): fix output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pdfDoc
 
 ```javascript
 const HummusRecipe = require('hummus-recipe');
-const pdfDoc = new HummusRecipe('new', '/output.pdf',{
+const pdfDoc = new HummusRecipe('new', 'output.pdf',{
     version: 1.6,
     author: 'John Doe',
     title: 'Hummus Recipe',


### PR DESCRIPTION
Fix the output directory relative so it can run anywhere without errors. Before it was giving this error:
```js
/Users/admejiar/Code/meanshop2/server/node_modules/hummus-recipe/lib/Recipe.js:65
            this.writer = hummus.createWriter(this.output, {
                                 ^

TypeError: Unable to create PDF file, make sure that output file target is available
    at Recipe._createWriter (/Users/admejiar/Code/meanshop2/server/node_modules/hummus-recipe/lib/Recipe.js:65:34)
    at new Recipe (/Users/admejiar/Code/meanshop2/server/node_modules/hummus-recipe/lib/Recipe.js:59:14)
    at Object.<anonymous> (/Users/admejiar/Code/meanshop2/server/index.js:2:16)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
```