### PR TITLE
Recipe can now open password protected files #109

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -16,11 +16,34 @@ const streams = require('memory-streams');
  * @param {string} [options.subject] - The subject
  * @param {string} [options.colorspace] - The default colorspace: rgb, cmyk, gray
  * @param {string[]} [options.keywords] - The array of keywords
+ * @param {string} [options.password] - permission password
+ * @param {string} [options.userPassword] - this 'view' password also enables encryption
+ * @param {string} [options.ownerPassword] - this allows owner to 'edit' file
+ * @param {string} [options.userProtectionFlag] - encryption security level (see permissions)
  */
 class Recipe {
     constructor(src, output, options = {}) {
-        this.src = src;
-        this.options = options;
+        this.src = src.toLowerCase();
+        this.encryptOptions = this._getEncryptOptions(options, (src === 'new'));
+        this.options = Object.assign({}, options, this.encryptOptions);
+        // this.encryptOptions = {};
+
+        // // gather possible encryption options
+        // for (let index = 0; index < encryptOptions.length; index++) {
+        //     const eo = encryptOptions[index];
+        //     if (options[eo]) {
+        //         this.encryptOptions[eo] = options[eo];
+        //         this.hasEncryption = true;
+        //     }
+        // }
+
+        // To get encryption to work requires both of these passwords
+        // The encryption is done via userPassword only when creating a new file.
+        // The password option is required by other hummus interfaces once
+        // encryption actually occurs.
+        // if (this.options.userPassword && !this.options.password) {
+        //     this.options.password = this.encryptOptions.password = this.options.userPassword;
+        // }
 
         // detect the src is Buffer or not
         this.isBufferSrc = this.src instanceof Buffer;
@@ -60,11 +83,13 @@ class Recipe {
     }
 
     _createWriter() {
-        if (!this.isBufferSrc && this.src.toLowerCase() == 'new') {
+        if (!this.isBufferSrc && this.src == 'new') {
             this.isNewPDF = true;
-            this.writer = hummus.createWriter(this.output, {
+            this.writer = hummus.createWriter(this.output, 
+                Object.assign( {}, this.encryptOptions, {
                 version: this._getVersion(this.options.version)
-            });
+                })
+            );
         } else {
             this.isNewPDF = false;
             this.read();
@@ -72,15 +97,18 @@ class Recipe {
                 if (this.isBufferSrc) {
                     this.writer = hummus.createWriterToModify(
                         new hummus.PDFRStreamForBuffer(this.src),
-                        new hummus.PDFStreamForResponse(this.outStream), {
+                        new hummus.PDFStreamForResponse(this.outStream), 
+                        Object.assign( {}, this.encryptOptions, {
                             log: this.logFile
-                        }
+                        })
                     );
                 } else {
-                    this.writer = hummus.createWriterToModify(this.src, {
-                        modifiedFilePath: this.output,
-                        log: this.logFile
-                    });
+                    this.writer = hummus.createWriterToModify(this.src, 
+                        Object.assign( {}, this.encryptOptions, {
+                            modifiedFilePath: this.output,
+                            log: this.logFile
+                        })
+                    );
                 }
             } catch (err) {
                 throw new Error(err);
@@ -120,7 +148,7 @@ class Recipe {
             if (this.isBufferSrc) {
                 src = new hummus.PDFRStreamForBuffer(this.src);
             }
-            const pdfReader = hummus.createReader(src);
+            const pdfReader = hummus.createReader(src, this.encryptOptions);
             const pages = pdfReader.getPagesCount();
             if (pages == 0) {
                 // broken or modify password protected
@@ -206,15 +234,18 @@ class Recipe {
 
                 this.writer = hummus.createWriterToModify(
                     new hummus.PDFRStreamForBuffer(oldStream.toBuffer()),
-                    new hummus.PDFStreamForResponse(this.outStream), {
+                    new hummus.PDFStreamForResponse(this.outStream),
+                    Object.assign( {}, this.encryptOptions, {
                         log: this.logFile
-                    }
+                    })
                 );
             } else {
-                this.writer = hummus.createWriterToModify(this.output, {
-                    modifiedFilePath: this.output,
-                    log: this.logFile
-                });
+                this.writer = hummus.createWriterToModify(this.output, 
+                    Object.assign( {}, this.encryptOptions, {
+                        modifiedFilePath: this.output,
+                        log: this.logFile
+                    })
+                );
             }
 
             this._writeAnnotations();

--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -23,30 +23,12 @@ const streams = require('memory-streams');
  */
 class Recipe {
     constructor(src, output, options = {}) {
-        this.src = src.toLowerCase();
-        this.encryptOptions = this._getEncryptOptions(options, (src === 'new'));
-        this.options = Object.assign({}, options, this.encryptOptions);
-        // this.encryptOptions = {};
-
-        // // gather possible encryption options
-        // for (let index = 0; index < encryptOptions.length; index++) {
-        //     const eo = encryptOptions[index];
-        //     if (options[eo]) {
-        //         this.encryptOptions[eo] = options[eo];
-        //         this.hasEncryption = true;
-        //     }
-        // }
-
-        // To get encryption to work requires both of these passwords
-        // The encryption is done via userPassword only when creating a new file.
-        // The password option is required by other hummus interfaces once
-        // encryption actually occurs.
-        // if (this.options.userPassword && !this.options.password) {
-        //     this.options.password = this.encryptOptions.password = this.options.userPassword;
-        // }
-
+        this.src = src;
         // detect the src is Buffer or not
         this.isBufferSrc = this.src instanceof Buffer;
+        this.isNewPDF = (!this.isBufferSrc && src.toLowerCase() === 'new');
+        this.encryptOptions = this._getEncryptOptions(options, this.isNewPDF);
+        this.options = Object.assign({}, options, this.encryptOptions);
 
         if (this.isBufferSrc) {
             this.outStream = new streams.WritableStream();
@@ -83,15 +65,13 @@ class Recipe {
     }
 
     _createWriter() {
-        if (!this.isBufferSrc && this.src == 'new') {
-            this.isNewPDF = true;
+        if (this.isNewPDF) {
             this.writer = hummus.createWriter(this.output, 
                 Object.assign( {}, this.encryptOptions, {
                 version: this._getVersion(this.options.version)
                 })
             );
         } else {
-            this.isNewPDF = false;
             this.read();
             try {
                 if (this.isBufferSrc) {

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -42,27 +42,34 @@ exports.permission = function permission(flags='print') {
 }
 
 exports._getEncryptOptions = function _getEncryptOptions(options, addPermissions=true) {
-    const encryptOptions = {
-        userPassword: ''
-    };
-
-    if(addPermissions) { // add default permissions for 'new' files
-        encryptOptions.userProtectionFlag = this.permission();
-    }
+    const encryptOptions = {};
 
     const password = options.password || options.ownerPassword;
     if (password) {
         encryptOptions.password = password;
         encryptOptions.ownerPassword = password;
     }
+
     if (options.userPassword) {
         encryptOptions.userPassword = options.userPassword;
         if (!encryptOptions.password) {
             encryptOptions.password = options.userPassword;
         }
     }
-    if (options.userProtectionFlag && addPermissions) {
-        encryptOptions.userProtectionFlag = options.userProtectionFlag;
+
+    if (addPermissions) { 
+        if (options.userProtectionFlag) {
+            encryptOptions.userProtectionFlag = options.userProtectionFlag;
+        }
+    }
+
+    // Only attach encryption mechanism when attributes 
+    // have been explicitly given in the incoming options.
+    if (Object.keys(encryptOptions) > 0 && !encryptOptions.userPassword) {
+        encryptOptions.userPassword = '';
+        if (!encryptOptions.userProtectionFlag) {
+            encryptOptions.userProtectionFlag = this.permission();
+        }
     }
 
     return encryptOptions;

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -1,32 +1,87 @@
 const hummus = require('hummus');
 const fs = require('fs');
 
+
+/**
+ * Encryption user access permissions
+ * 
+ * This function supplies the numeric value for the encrypt function's 'userProtectionFlag'
+ * option. When no argument is given, the default 'print' value is used.
+ * 
+ * @name permission
+ * @function
+ * @memberof Recipe
+ * @param {string} flags from the list print, modify, copy, edit, fillform, extract, assemble, and printbest
+ * More than one may be specified by using a comma to separate the names in the input string.
+ */
+exports.permission = function permission(flags='print') { 
+
+    // https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf
+
+    const userAccessPermissions = {  // see table on page 61 of above document
+        'print'    : 1<<2,   // allow printing
+        'modify'   : 1<<3,   // allow template creation, signing, filling form fields
+        'copy'     : 1<<4,   // allow content copying and copying for accessibility
+        'edit'     : 1<<5,   // allow commenting
+        'fillform' : 1<<8,   // allow filling of form fields
+        'extract'  : 1<<9,   // allow content copying for accessibility
+        'assemble' : 1<<10,  // unused
+        'printbest': 1<<11   // allow high resolution printing when 'print' is allowed
+    };
+
+    const perms = flags.split(',').map((x)=>{return x.trim()});
+    let access = 0;
+    perms.forEach((perm) => {
+        if (!userAccessPermissions[perm]) {
+            throw new Error(`Unknown user access permission (${perm})`);
+        }
+        access += userAccessPermissions[perm];
+    })
+
+    return access;
+}
+
+exports._getEncryptOptions = function _getEncryptOptions(options, addPermissions=true) {
+    const encryptOptions = {
+        userPassword: ''
+    };
+
+    if(addPermissions) { // add default permissions for 'new' files
+        encryptOptions.userProtectionFlag = this.permission();
+    }
+
+    const password = options.password || options.ownerPassword;
+    if (password) {
+        encryptOptions.password = password;
+        encryptOptions.ownerPassword = password;
+    }
+    if (options.userPassword) {
+        encryptOptions.userPassword = options.userPassword;
+        if (!encryptOptions.password) {
+            encryptOptions.password = options.userPassword;
+        }
+    }
+    if (options.userProtectionFlag && addPermissions) {
+        encryptOptions.userProtectionFlag = options.userProtectionFlag;
+    }
+
+    return encryptOptions;
+}
+
 /**
  * Encrypt the pdf
  * @name encrypt
  * @function
  * @memberof Recipe
  * @param {Object} options - The options
- * @param {string} [options.password] - The password for viewing.
+ * @param {string} [options.password] - The permission password.
  * @param {string} [options.ownerPassword] - The password for editing.
+ * @param {string} [options.userPassword] - The password for viewing & encryption.
  * @param {number} [options.userProtectionFlag] - The flag for the security level.
  */
 exports.encrypt = function encrypt(options = {}) {
     this.needToEncrypt = true;
-    this.encryption_ = {
-        userProtectionFlag: 4
-    };
-    const password = options.password || options.ownerPassword;
-    if (password) {
-        this.encryption_.password = password;
-        this.encryption_.ownerPassword = password;
-    }
-    if (options.userPassword) {
-        this.encryption_.userPassword = options.userPassword;
-    }
-    if (options.userProtectionFlag) {
-        this.encryption_.userProtectionFlag = options.userProtectionFlag;
-    }
+    this.encryption_ = this._getEncryptOptions(options);
 
     return this;
 };
@@ -36,9 +91,7 @@ exports._encrypt = function _encrypt() {
     if (!this.encryption_) {
         return;
     }
-    if (!this.encryption_.userPassword) {
-        this.encryption_.userPassword = '';
-    }
+    
     const tmp = this.output + '.tmp.pdf';
     fs.renameSync(this.output, tmp);
     hummus.recrypt(tmp, this.output, this.encryption_);

--- a/lib/info.js
+++ b/lib/info.js
@@ -29,7 +29,7 @@ exports._writeInfo = function _writeInfo() {
     if (!this.isNewPDF) {
         // reuse copyCtx?
         const copyFrom = this.isBufferSrc ? new hummus.PDFRStreamForBuffer(this.src) : this.src;
-        const copyCtx = this.writer.createPDFCopyingContext(copyFrom);
+        const copyCtx = this.writer.createPDFCopyingContext(copyFrom, options);
         const infoDict = copyCtx.getSourceDocumentParser().queryDictionaryObject(
             copyCtx.getSourceDocumentParser().getTrailer(), 'Info'
         );

--- a/tests/encryption.js
+++ b/tests/encryption.js
@@ -28,4 +28,69 @@ describe('Encryption', () => {
             .endPDF(done);
     });
 
+    const taskAPP = 'Add permission password';
+    it(taskAPP, (done) => {
+        const src = path.join(__dirname, 'materials/test2.pdf');
+        // const overlayPDF = path.join(__dirname, 'materials/test3.pdf');
+        const output = path.join(__dirname, `output/${taskAPP}.pdf`);
+
+        const recipe = new HummusRecipe(src, output);
+        recipe
+            .encrypt({
+                password: '123',
+            })
+            .endPDF(done);
+    });
+
+    const taskCPF = 'New file with view password';
+    it(taskCPF, (done) => {
+        const output = path.join(__dirname, `output/${taskCPF}.pdf`);
+        const recipe = new HummusRecipe('new', output, {userPassword: '123'});
+        recipe
+            .createPage('letter-size')
+            .text('When creating file, the viewing password (userPassword)', 150, 300)
+            .text('is required for file encryption to occur.', 150, 350)
+            .endPage()
+            .endPDF(done);
+    });
+
+    const taskCPP = 'New file with permission password';
+    it(taskCPP, (done) => {
+        const output = path.join(__dirname, `output/${taskCPP}.pdf`);
+        const recipe = new HummusRecipe('new', output, {password: '123'});
+        recipe
+            .createPage('letter-size')
+            .text('When creating file, an empty viewing password (userPassword)', 150, 300)
+            .text('is required for file encryption to occur.', 150, 350)
+            .endPage()
+            .endPDF(done);
+    });
+
+    const taskCPE = 'New file with edit password';
+    it(taskCPE, (done) => {
+        const output = path.join(__dirname, `output/${taskCPE}.pdf`);
+        const a=3900
+        console.log(`perm: ${a.toString(2)}`)
+        const recipe = new HummusRecipe('new', output, {ownerPassword: '123', userProtectionFlag:3900});
+        recipe
+            .createPage('letter-size')
+            .text('When creating file, an empty viewing password (userPassword)', 150, 300)
+            .text('is required for file encryption to occur.', 150, 350)
+            .endPage()
+            .endPDF(done);
+    });
+
+    const taskMPF = 'Modify file with view password';
+    it(taskMPF, (done) => {
+        const input  = path.join(__dirname, `output/${taskCPF}.pdf`);
+        const output = path.join(__dirname, `output/${taskMPF}.pdf`);
+        const recipe = new HummusRecipe(input, output, {userPassword: '123'});
+
+        recipe
+            .editPage(1)
+            .text('The userPassword is also required to modify the file.', 150, 400)
+            .endPage()
+            .endPDF(done);
+    });
+
 });

--- a/tests/encryption.js
+++ b/tests/encryption.js
@@ -70,7 +70,6 @@ describe('Encryption', () => {
     it(taskCPE, (done) => {
         const output = path.join(__dirname, `output/${taskCPE}.pdf`);
         const a=3900
-        console.log(`perm: ${a.toString(2)}`)
         const recipe = new HummusRecipe('new', output, {ownerPassword: '123', userProtectionFlag:3900});
         recipe
             .createPage('letter-size')


### PR DESCRIPTION
Previously, Recipe.encrypt would be able to add passwords to generated files, but once they were protected, they could no longer be accessed by subsequent Recipe actions. Theses changes fix that problem.