### PR TITLE
Changes to allow object skew #111

### DIFF
--- a/lib/vector.helper.js
+++ b/lib/vector.helper.js
@@ -73,6 +73,15 @@ exports._getPathOptions = function _getPathOptions(options = {}, originX, origin
         pathOptions.rotationOrigin = options.rotationOrigin || null;
     }
 
+    // skew
+    if (options.skewX !== void(0)) {
+        pathOptions.skewX = options.skewX;
+    }
+
+    if (options.skewY != void(0)) {
+        pathOptions.skewY = options.skewY;
+    }
+
     // Page 127
     pathOptions.dash = (Array.isArray(options.dash)) ? options.dash : [];
     pathOptions.dashPhase = (!isNaN(options.dashPhase)) ? options.dashPhase : 0;
@@ -257,7 +266,7 @@ exports._getDistance = function _getDistance(coordA, coordB) {
 exports._getTransformParams = getTransformParams;
 
 function getTransformParams(inAngle, x, y, offsetX, offsetY) {
-    const theta = 2 * Math.PI * ((inAngle % 360) / 360);
+    const theta = toRadians(inAngle);
     const cosTheta = Math.cos(theta);
     const sinTheta = Math.sin(theta);
     const nx = (cosTheta * -offsetX) + (sinTheta * -offsetY);
@@ -286,6 +295,27 @@ exports._setRotationContext = function _setRotationTransform(context, x, y, opti
     }
 };
 
+function toRadians(angle) {
+    return 2 * Math.PI * ((angle % 360) / 360);
+}
+
+function getSkewTransform(skewXAngle= 0 , skewYAngle = 0) {
+    const alpha = toRadians(skewXAngle);
+    const beta  = toRadians(skewYAngle);
+    const tanAlpha = Math.tan(alpha);
+    const tanBeta  = Math.tan(beta);
+
+    return [1, tanAlpha, tanBeta, 1, 0, 0];
+}
+
+exports._setSkewContext = function _setSkewTransform(context, options) {
+    if (options.skewX || options.skewY) {
+        const sm = getSkewTransform(options.skewX, options.skewY);
+
+        context.cm(sm[0], sm[1], sm[2], sm[3], sm[4], sm[5]);
+    }
+};
+
 exports._drawObject = function _drawObject(self, x, y, width, height, options, callback) {
 
     self.pauseContext();
@@ -303,6 +333,7 @@ exports._drawObject = function _drawObject(self, x, y, width, height, options, c
     const context = self.pageContext;
     context.q();
     self._setRotationContext(context, x, y, options);
+    self._setSkewContext(context, options);
     context
         .doXObject(xObject)
         .Q();

--- a/lib/vector.js
+++ b/lib/vector.js
@@ -35,7 +35,7 @@ exports.circle = function circle(x, y, radius, options = {}) {
     const diameter = radius * 2;
 
     if (options.fill) {
-        const pathOptions = this._getPathOptions(options);
+        const pathOptions = this._getPathOptions(options, nx, ny);
         pathOptions.type = 'fill';
 
         if (pathOptions.fill !== undefined) {

--- a/tests/vector.js
+++ b/tests/vector.js
@@ -17,12 +17,21 @@ describe('Vector', () => {
                 opacity: 0.1
             })
             .rectangle(500, 50, 50, 50, {
+                fill: [255, 0, 0],
+                skewY: -20
+            })
+            .rectangle(500, 50, 50, 50, {
                 color: [255, 0, 255],
                 opacity: 0.2
             })
             .rectangle(500, 150, 50, 50, {
                 color: [255, 0, 255],
                 opacity: 0.4
+            })
+            .rectangle(500, 250, 50, 50, {
+                fill: [255, 0, 255],
+                opacity: 0.6,
+                skewX: 10
             })
             .rectangle(500, 250, 50, 50, {
                 color: [255, 0, 255],
@@ -64,6 +73,11 @@ describe('Vector', () => {
                 stroke: '#0032FF',
                 dash: [5, 5]
             })
+            .circle(400, 250, 20, {color:"#00ff00"})
+            .circle(400, 250, 20, {skewX:30})
+            .circle(400, 250, 20, {skewY:-20})
+            .ellipse(100, 650, 30, 10)
+            .ellipse(100, 650, 30, 10, {skewY: 30, fill:"#00ff00", opacity:.2, stroke:"#ff0000", width:1})
             .polygon([
                 [0, 0],
                 [0, 300],
@@ -100,6 +114,14 @@ describe('Vector', () => {
                 fill: '#0000ff',
                 stroke: '#0000ff',
                 opacity: 0
+            })
+            .polygon([
+                [300, 300],
+                [450, 600],
+                [150, 600]
+            ], {
+                stroke: '#ff0000',
+                skewY: 20
             })
             .polygon([
                 [250, 650],


### PR DESCRIPTION
All drawing objects should be able to be skewed in x and y direction with these changes.

skewX and skewY are available in all graphic objects. Units are in angle degrees.