### PR TITLE
Rounded rectangle feature #112

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -102,6 +102,7 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
     }
 
     const pathOptions = this._getPathOptions(options, nx, ny);
+    let colorModel = pathOptions.colorModel;
 
     if (options.fill) {
         pathOptions.type = 'fill';
@@ -109,12 +110,19 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
         if (pathOptions.fill !== undefined) {
             pathOptions.color = pathOptions.fill;
             pathOptions.colorspace = pathOptions.fillModel.colorspace;
+            colorModel = pathOptions.fillModel;
         }
 
         this._drawObject(this, nx, ny, width, height, pathOptions, (ctx, xObject) => {
-            ctx
-                .gs(xObject.getGsName(pathOptions.fillGsId))
-                .drawRectangle(0, 0, width, height, pathOptions);
+            ctx.gs(xObject.getGsName(pathOptions.fillGsId));
+
+            if (options.borderRadius) {
+                xObject.fill(colorModel);
+                drawRoundedRectangle(ctx, 0, 0, width, height, options.borderRadius);
+                ctx.f();
+            } else {
+                ctx.drawRectangle(0, 0, width, height, pathOptions);
+            }
         });
     }
 
@@ -124,22 +132,79 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
         if (pathOptions.stroke !== undefined) {
             pathOptions.color = pathOptions.stroke;
             pathOptions.colorspace = pathOptions.strokeModel.colorspace;
+            colorModel = pathOptions.strokeModel;
         }
 
         // To honor the given width and height of the rectangle ...
 
-        this._drawObject(this, nx, ny, width, height, pathOptions, (ctx) => {
-            const margin = pathOptions.width;
-            ctx
-                .d(pathOptions.dash, pathOptions.dashPhase)
-                .drawRectangle(margin/2, margin/2, width-margin, height-margin, pathOptions);
+        this._drawObject(this, nx, ny, width, height, pathOptions, (ctx, xObject) => {
 
-                // ... requires adjusting the internal drawing to accomodate line thickness.
+            // ... requires adjusting the internal drawing to accomodate line thickness.
+            const margin = pathOptions.width;
+
+            if (options.borderRadius) {
+                xObject.stroke(colorModel);
+                ctx
+                    .w(pathOptions.width)
+                    .d(pathOptions.dash, pathOptions.dashPhase)
+    
+                drawRoundedRectangle(ctx, margin/2, margin/2, width-margin, height-margin, options.borderRadius);
+                ctx.S();
+            } else {
+                ctx
+                    .d(pathOptions.dash, pathOptions.dashPhase)
+                    .drawRectangle(margin/2, margin/2, width-margin, height-margin, pathOptions);
+            }
         });
     }
 
     return this;
 };
+
+function drawRoundedRectangle( ctx, left, bottom, width, height, radii) {
+    let radius = [];
+
+    // populate radius array accordingly.
+    // Missing element value comes from opposite corner.
+    if (typeof radii === 'number') {
+        radius = new Array(4).fill(radii);
+    } else if (Array.isArray(radii)) {
+        switch(radii.length) {
+            case 1:
+                radius = new Array(4).fill(radii[0]);
+                break;
+            case 2:
+                radius    = radii.slice(0);
+                radius[2] = radii[0];
+                radius[3] = radii[1];
+                break;
+            case 3:
+                radius = radii.slice(0);
+                radius[3] = radii[1];
+                break;
+            case 4:
+                radius = radii;
+                break;
+        }
+    }
+    const K = 0.551784;
+    const right=left+width;
+    const top=bottom+height;
+    ctx
+        .m(left, top-radius[0])       // top-left
+        .c(left, top-radius[0]*(1-K), left+radius[0]*(1-K), top, left+radius[0], top)
+
+        .l(right-radius[1], top)      // top-right
+        .c(right-radius[1]*(1-K), top, right, top-radius[1]*(1-K), right, top-radius[1])
+
+        .l(right,bottom+radius[2])    // bottom-right
+        .c(right,bottom+radius[2]*(1-K), right-radius[2]*(1-K), bottom, right-radius[2], bottom)
+
+        .l(left+radius[3], bottom)   // bottom-left
+        .c(left+radius[3]*(1-K), bottom, left, bottom+radius[3]*(1-K),left,bottom+radius[3])
+
+        .l(left, top-radius[0])      // back to top-left     
+}
 
 /**
  * Draw an ellipse
@@ -171,26 +236,21 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
         options.rotationOrigin = [orig.nx, orig.ny];
     }
 
+    const width  = rx*2;
+    const height = ry*2;
     const pathOptions = this._getPathOptions(options, nx, ny);
     let colorModel = pathOptions.colorModel;
+    
+    const drawEllipse = (ctx, x, y, w, h) => {
 
-    // Algorithm has to account for thickness of line to keep
-    // ellipse within the confines of the enclosing rectangle
-    // so that there is no viewed clipping of the drawn path.
+        const magic = 0.551784;  // from https://www.tinaja.com/glib/ellipse4.pdf
+        const ox = rx * magic;   // control point offset horizontal
+        const oy = ry * magic;   // control point offset horizontal
+        const xe = x + w;        // x-end, opposite corner from origin
+        const ye = y + h;        // y-end, opposite corner from origin
+        const xm = rx;           // x-middle of enclosing rectangle
+        const ym = ry;           // y-middle of enclosing rectangle
 
-    const magic = 0.551784;  // from https://www.tinaja.com/glib/ellipse4.pdf
-    const ox = rx * magic;   // control point offset horizontal
-    const oy = ry * magic;   // control point offset horizontal
-    const w  = rx * 2;       // width of enclosing rectangle
-    const h  = ry * 2;       // height of enclosing rectangle
-    const x = 0;             // x coordinate of origin
-    const y = 0;             // y coordinate of origin
-    const xe = x + w;        // x-end, opposite corner from origin
-    const ye = y + h;        // y-end, opposite corner from origin
-    const xm = rx;           // x-middle of enclosing rectangle
-    const ym = ry;           // y-middle of enclosing rectangle
-
-    const drawEllipse = (ctx, x, y, xe, ye) => {
         ctx
             .m(x, ym)
             .c(x, ym - oy, xm - ox, y, xm, y)
@@ -205,11 +265,11 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
             colorModel = pathOptions.fillModel;
         }
 
-        this._drawObject(this, nx-rx, ny-ry, w, h, pathOptions, (ctx, xObject) => {
+        this._drawObject(this, nx-rx, ny-ry, width, height, pathOptions, (ctx, xObject) => {
             
             ctx.gs(xObject.getGsName(pathOptions.fillGsId));
             xObject.fill(colorModel);
-            drawEllipse(ctx, x, y, xe, ye);
+            drawEllipse(ctx, 0, 0, width, height);
             ctx.f();
         });
     }
@@ -222,7 +282,7 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
 
         // To honor the given width and height of the enclosing rectangle ...
 
-        this._drawObject(this, nx-rx, ny-ry, w, h, pathOptions, (ctx, xObject) => {
+        this._drawObject(this, nx-rx, ny-ry, width, height, pathOptions, (ctx, xObject) => {
             const margin = pathOptions.width/2;
             xObject.stroke(colorModel);
             ctx
@@ -230,7 +290,7 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
                 .d(pathOptions.dash, pathOptions.dashPhase)
 
             // ... requires adjusting the internal drawing to accomodate line thickness.
-            drawEllipse(ctx, margin, margin, xe-margin, ye-margin);
+            drawEllipse(ctx, margin, margin, width-margin, height-margin);
             ctx.S();
         });
     }

--- a/tests/vector.js
+++ b/tests/vector.js
@@ -78,6 +78,9 @@ describe('Vector', () => {
             .circle(400, 250, 20, {skewY:-20})
             .ellipse(100, 650, 30, 10)
             .ellipse(100, 650, 30, 10, {skewY: 30, fill:"#00ff00", opacity:.2, stroke:"#ff0000", width:1})
+            .rectangle(10, 320, 80, 100, {borderRadius:5})
+            .rectangle(15, 325, 70, 90, {borderRadius:[5,10], stroke:"#00ff00"})
+            .rectangle(20, 330, 60, 80, {borderRadius:[20,10,5], fill:"#ff00ff"})
             .polygon([
                 [0, 0],
                 [0, 300],


### PR DESCRIPTION
Rounded rectangles can be obtained using the borderRadius option to the rectangle interface. A single numeric value given will apply to all 4 corners. An array with 1 to 4 values can be used to apply different radii to corners in the order topLeft, topRight, bottomRight, bottomLeft. Missing values are applied as specified by CSS rules. (https://www.w3schools.com/cssref/css3_pr_border-radius.asp)