### PR TITLE
Fix for text alignment issue #122

### DIFF
--- a/lib/text.helper.js
+++ b/lib/text.helper.js
@@ -40,6 +40,11 @@ exports.Line = class Line {
         return (toWidth <= this.width);
     }
 
+    replaceLastWord(wordObject) {
+        this.wordObjects.pop();
+        this.addWord(wordObject);
+    }
+
     get spaceWidth() {
         return this._pathOptions.font.calculateTextDimensions(
             'o', this.size
@@ -57,7 +62,7 @@ exports.Line = class Line {
     get currentWidth() {
         return this._pathOptions.font.calculateTextDimensions(
             this.value, this.size
-        ).width;
+        ).xMax;
     }
 
     get textWidth() {

--- a/lib/text.js
+++ b/lib/text.js
@@ -62,6 +62,7 @@ exports.text = function text(text = '', x, y, options = {}) {
     const targetAnnotations = options;
     const originCoord = this._calibrateCoordinate(x, y, 0, 0, this.pageNumber);
     const pathOptions = this._getPathOptions(options, originCoord.nx, originCoord.ny);
+    pathOptions.html = options.html;
     // const { width: pageWidth, height: pageHeight } = this.metadata[this.pageNumber];
 
     const textObjects = (options.html) ? htmlToTextObjects(text) : [{
@@ -204,10 +205,11 @@ exports.text = function text(text = '', x, y, options = {}) {
         ny
     } = this._calibrateCoordinate(x, y, offsetX, offsetY);
     if (textBox.style) {
-        textBox.height = (textBox.firstLineHeight + 2) * toWriteTextObjects.length;
+        textBox.height = textBox.firstLineHeight * toWriteTextObjects.length 
+                       + textBox.paddingTop + textBox.paddingBottom;
         this.rectangle(
             nx,
-            ny - textBox.height + textBox.firstLineHeight,
+            ny - textBox.height + textBox.baselineHeight + textBox.paddingTop + textBox.paddingBottom,
             textBox.width, textBox.height, Object.assign(textBox.style, {
                 useGivenCoords: true,
                 rotation: pathOptions.rotation,
@@ -217,7 +219,7 @@ exports.text = function text(text = '', x, y, options = {}) {
     }
     const context = this.pageContext;
     // const space = 8;
-    let currentY = ny - textBox.paddingTop;
+    let currentY = ny + textBox.paddingBottom;
     let currentLineID;
     let currentLineWidth = 0;
     let toWriteContents = [];
@@ -253,7 +255,7 @@ exports.text = function text(text = '', x, y, options = {}) {
             const {lineHeight, lineWidth, text} = wto;
 
             // write directly to page when not dealing with opacity and rotation.
-            if (options.opacity === 1 && options.rotation === 0) {
+            if (options.opacity === 1 && (options.rotation === 0 || options.rotation === undefined)) {
                 context.writeText(text, x, y, options);
             } else {
                 // ... otherwise use xObjectForm when rotation or opacity exists
@@ -326,7 +328,7 @@ exports.text = function text(text = '', x, y, options = {}) {
             });
         }
 
-        currentLineWidth = currentLineWidth + lineWidth + spaceWidth; // space * writeOptions.size / 14;
+        currentLineWidth = currentLineWidth + lineWidth + spaceWidth;
 
         // Processing last line?
         if (index == toWriteTextObjects.length - 1) {
@@ -349,12 +351,15 @@ function getToWriteTextObjects(textObject = {}, pathOptions, textBox = {}) {
 
     const size = textObject.size || pathOptions.size;
     // Use the same string to get the same height for each string with the same font.
-    const textHeight = pathOptions.font.calculateTextDimensions(
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZ', size
-    ).height;
+    // Need lowercase 'gjpqy' so descenders are included in text height.
+    const textDimensions = pathOptions.font.calculateTextDimensions(
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZgjpqy', size
+    );
+    const textHeight = textDimensions.height;
 
     pathOptions.textHeight = textHeight;
     textBox.lineHeight = textBox.lineHeight || textHeight;
+    textBox.baselineHeight = textDimensions.yMax;
 
     const breaker = new LineBreaker(text);
     const lines = [];
@@ -364,6 +369,7 @@ function getToWriteTextObjects(textObject = {}, pathOptions, textBox = {}) {
     let newLine = new Line(lineMaxWidth, textBox.lineHeight, size, pathOptions);
     let last = 0;
     let bk = breaker.nextBreak();
+    let previousWord;
 
     for (let i = 0; i < indent; i++) {
         newLine.addWord(new Word(' '));
@@ -384,6 +390,10 @@ function getToWriteTextObjects(textObject = {}, pathOptions, textBox = {}) {
         if (newLine.canFit(word)) {
             newLine.addWord(word);
         } else {
+            // remove any trailing space on previous word so right justification works appropriately
+            if ( previousWord ) {
+                newLine.replaceLastWord(new Word(previousWord.value.trim(), pathOptions));
+            }
             lines.push(newLine);
             newLine = new Line(lineMaxWidth, textBox.lineHeight, size, pathOptions);
             for (let i = 0; i < indent; i++) {
@@ -405,6 +415,7 @@ function getToWriteTextObjects(textObject = {}, pathOptions, textBox = {}) {
             lines.push(newLine);
             newLine = new Line(lineMaxWidth, textBox.lineHeight, size, pathOptions);
         }
+        previousWord = word;
         last = bk.position;
         bk = breaker.nextBreak();
     }
@@ -424,13 +435,15 @@ function getToWriteTextObjects(textObject = {}, pathOptions, textBox = {}) {
     lines.forEach((line, index) => {
         lineHeight = (lineHeight >= line.height) ? lineHeight : line.height;
 
+        // Space width only gets applied for HTML elements.
+        // Otherwise, normal text alignments (center,right) are shifted left by a space.
         toWriteTextObjects.push({
             text: line.value,
             lineID: (index == 0) ? textObject.lineID : Date.now() * Math.random(),
             // @todo: handle line height to mimic html tag
             lineHeight,
             lineWidth: line.currentWidth,
-            spaceWidth: line.spaceWidth,
+            spaceWidth: (pathOptions.html) ? line.spaceWidth : 0,
             writeOptions
         });
         paragraphHeight += lineHeight;

--- a/lib/vector.js
+++ b/lib/vector.js
@@ -290,7 +290,7 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
                 .d(pathOptions.dash, pathOptions.dashPhase)
 
             // ... requires adjusting the internal drawing to accomodate line thickness.
-            drawEllipse(ctx, margin, margin, width-margin, height-margin);
+            drawEllipse(ctx, margin, margin, width-pathOptions.width, height-pathOptions.width);
             ctx.S();
         });
     }

--- a/tests/text-centering.js
+++ b/tests/text-centering.js
@@ -4,57 +4,82 @@ const HummusRecipe = require('../lib');
 describe('Text - Centering', () => {
 
     it('should horizontally center the text correctly with multiple font sizes', (done) => {
-        const src = path.join(__dirname, 'materials/blank.pdf');
         const output = path.join(__dirname, 'output/Center Text.pdf');
-        const recipe = new HummusRecipe(src, output);
+        const recipe = new HummusRecipe('new', output);
 
         recipe
-            .editPage(1)
-            .text('Test', 30, 240, {
+            .createPage('letter-size')
+            .line([[180,0],[180,300]],{stroke:"#ff00ff",lineWidth:.5})
+            .text('Musty', 30, 230, {
                 color: '#000000',
                 font: 'Arial',
                 size: 12,
                 textBox: {
                     width: 300,
-                    minHeight: 100,
+                    // minHeight: 100,
                     textAlign: 'center',
-                    padding: [0, 0, 0, 0],
+                    padding: 0,
                     style: {
-                        stroke: '#000000'
+                        stroke: '#000000',
+                        lineWidth:1,
+                        fill:'#ffffff'
                     }
                 },
 
             })
-            .text('Test', 30, 20, {
+
+            .text('Dusty', 30, 50, {
                 color: '#000000',
                 font: 'Arial',
                 size: 30,
                 textBox: {
                     width: 300,
-                    minHeight: 100,
+                    // minHeight: 100,
                     textAlign: 'center',
-                    padding: [0, 0, 0, 0],
+                    padding: 0,
                     style: {
-                        stroke: '#000000'
+                        stroke: '#000000',
+                        lineWidth:1,
+                        fill:'#ffffff'
                     }
                 },
 
             })
-            .text('Test', 30, 130, {
+            .text('Testy', 30, 120, {
                 color: '#000000',
                 font: 'Arial',
-                size: 56,
+                size: 70,
                 textBox: {
                     width: 300,
-                    minHeight: 100,
+                    // height: 56,
+                    // minHeight: 100,
                     textAlign: 'center',
-                    padding: [0, 0, 0, 0],
+                    padding: [0,0,0,0],
                     style: {
-                        stroke: '#000000'
+                        stroke: '#000000',
+                        lineWidth:1,
+                        fill:'#ffff00'
                     }
                 },
 
             })
+            .text('A\nAAA\nOOO\nVVV\nY', 30, 260, {
+                color: '#000000',
+                font: 'Arial',
+                size: 30,
+                textBox: {
+                    width: 300,
+                    // minHeight: 100,
+                    textAlign: 'center',
+                    padding: 0,
+                    style: {
+                        stroke: '#000000',
+                        lineWidth:1,
+                        fill:'#ffffff'
+                    }
+                },
+            })
+            .line([[180,0],[180,700]],{stroke:"#ff00ff",lineWidth:.5})
             .endPage();
 
 


### PR DESCRIPTION
This fixes the problem with non-rotated text NOT being placed inside text box. The text box size now considers text descenders from letters like 'gjpqy' in its height computation. Centering and right justification behave better (by using xMax instead of width from hummus text calculations). I updated the centering test so that it is easier to spot text not centered properly.

Perusing the tests I noticed that ellipses were getting clipped and corrected that too.