### PR TITLE
Allow multiple font locations #129

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -20,6 +20,7 @@ const streams = require('memory-streams');
  * @param {string} [options.userPassword] - this 'view' password also enables encryption
  * @param {string} [options.ownerPassword] - this allows owner to 'edit' file
  * @param {string} [options.userProtectionFlag] - encryption security level (see permissions)
+ * @param {string|string[]} [options.fontSrcPath] - directory location(s) of additional fonts
  */
 class Recipe {
     constructor(src, output, options = {}) {

--- a/lib/font.js
+++ b/lib/font.js
@@ -14,15 +14,19 @@ exports.registerFont = function registerFont(fontName = '', fontSrcPath = '') {
 
 exports._loadFonts = function _loadFonts(fontSrcPath) {
     const fontTypes = ['.ttf', '.ttc', '.otf'];
-    fs
-        .readdirSync(fontSrcPath)
-        .filter((file) => {
-            return fontTypes.includes(path.extname(file).toLowerCase());
-        })
-        .forEach((file) => {
-            const fontName = path.basename(file, path.extname(file));
-            return this._registerFont(fontName, path.join(fontSrcPath, file));
-        });
+    const fontPaths = (typeof fontSrcPath === 'string') ? [fontSrcPath] : fontSrcPath;
+    
+    for (let fpath of fontPaths) {
+        fs
+            .readdirSync(fpath)
+            .filter((file) => {
+                return fontTypes.includes(path.extname(file).toLowerCase());
+            })
+            .forEach((file) => {
+                const fontName = path.basename(file, path.extname(file));
+                return this._registerFont(fontName, path.join(fpath, file));
+            });
+    }
 };
 
 exports._registerFont = function _registerFont(fontName, fontSrcPath) {


### PR DESCRIPTION
This update allows a user to be able to specify an array of path names to directories that should be searched for fonts.