### PR TITLE
Read document info #140

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -23,6 +23,7 @@ exports.info = function info(options = {}) {
  * @desc Obtain document information from existing PDF
  * @memberof Recipe
  * @function
+ * @returns object containing document information, or undefined.
  */
 exports.getDocumentInfo = function _readInfo() {
     if (!this.isNewPDF && !this.infoDictionary) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -18,23 +18,79 @@ exports.info = function info(options = {}) {
     return this;
 };
 
+/**
+ * @name getDocumentInfo
+ * @desc Obtain document information from existing PDF
+ * @memberof Recipe
+ * @function
+ */
+exports.getDocumentInfo = function _readInfo() {
+    if (!this.isNewPDF && !this.infoDictionary) {
+        const copyFrom = this.isBufferSrc ? new hummus.PDFRStreamForBuffer(this.src) : this.src;
+        const copyCtx  = this.writer.createPDFCopyingContext(copyFrom);
+        const infoDict = copyCtx.getSourceDocumentParser().queryDictionaryObject(
+            copyCtx.getSourceDocumentParser().getTrailer(), 'Info'
+        );
+    
+        const oldInfo = (infoDict && infoDict.toJSObject) ? infoDict.toJSObject() : null;
+    
+        if (oldInfo) {
+            this.infoDictionary = {}
+            Object.getOwnPropertyNames(oldInfo).forEach((key) => {
+                if (!oldInfo[key]) {
+                    return;
+                }
+                const oldInforSrc = this._parseObjectByType(oldInfo[key]);
+                if (!oldInforSrc) {
+                    return;
+                }
+                switch (key) {
+                    case 'Trapped':
+                        if (oldInforSrc && oldInforSrc.value) {
+                            this.infoDictionary.trapped = oldInforSrc.value;
+                        }
+                        break;
+                    case 'CreationDate':
+                        if (oldInforSrc && oldInforSrc.value) {
+                            this.infoDictionary.creationDate = oldInforSrc.value;
+                        }
+                        break;
+                    case 'ModDate':
+                        if (oldInforSrc && oldInforSrc.value) {
+                            this.infoDictionary.modDate = oldInforSrc.value;
+                        }
+                        break;
+                    case 'Creator':
+                        if (oldInforSrc && oldInforSrc.toText) {
+                            this.infoDictionary.creator = oldInforSrc.toText();
+                        }
+                        break;
+                    case 'Producer':
+                        if (oldInforSrc && oldInforSrc.toText) {
+                            this.infoDictionary.producer = oldInforSrc.toText();
+                        }
+                        break;
+                    default:
+                        if (oldInforSrc && oldInforSrc.toText) {
+                            this.infoDictionary[key.toLowerCase()] = oldInforSrc.toText();
+                        }
+                }
+            });
+        }
+    }
+
+    return this.infoDictionary;
+}
+
 exports._writeInfo = function _writeInfo() {
     const options = this.toWriteInfo_ || {};
-    let oldInfo;
+    const oldInfo = this.getDocumentInfo();
     /*
         #41, #48
         This issue is due to the unhandled process exit from HummusJS.
         I have to disable this part before it gets fixed in HummusJS.
     */
-    if (!this.isNewPDF) {
-        // reuse copyCtx?
-        const copyFrom = this.isBufferSrc ? new hummus.PDFRStreamForBuffer(this.src) : this.src;
-        const copyCtx = this.writer.createPDFCopyingContext(copyFrom, options);
-        const infoDict = copyCtx.getSourceDocumentParser().queryDictionaryObject(
-            copyCtx.getSourceDocumentParser().getTrailer(), 'Info'
-        );
-        oldInfo = (infoDict && infoDict.toJSObject) ? infoDict.toJSObject() : null;
-    }
+    
     const infoDictionary = this.writer.getDocumentContext().getInfoDictionary();
     const fields = [{
         key: 'author',
@@ -58,40 +114,25 @@ exports._writeInfo = function _writeInfo() {
             if (!oldInfo[key]) {
                 return;
             }
-            const oldInforSrc = this._parseObjectByType(oldInfo[key]);
-            if (!oldInforSrc) {
-                return;
-            }
+
             switch (key) {
-                case 'Trapped':
-                    if (oldInforSrc && oldInforSrc.value) {
-                        infoDictionary.trapped = oldInforSrc.value;
-                    }
+                case 'trapped':
+                    infoDictionary.trapped = oldInfo.trapped;
                     break;
-                case 'CreationDate':
-                    if (oldInforSrc && oldInforSrc.value) {
-                        infoDictionary.setCreationDate(oldInforSrc.value);
-                    }
+                case 'creationDate':
+                    infoDictionary.setCreationDate(oldInfo.creationDate);
                     break;
-                case 'ModDate':
-                    if (oldInforSrc && oldInforSrc.value) {
-                        infoDictionary.addAdditionalInfoEntry(`source-${key}`, oldInforSrc.value);
-                    }
+                case 'modDate':
+                    infoDictionary.addAdditionalInfoEntry('source-ModDate', oldInfo.modDate);
                     break;
-                case 'Creator':
-                    if (oldInforSrc && oldInforSrc.toText) {
-                        infoDictionary.addAdditionalInfoEntry(`source-${key}`, oldInforSrc.toText());
-                    }
+                case 'creator':
+                    infoDictionary.addAdditionalInfoEntry('source-Creator', oldInfo.creator);
                     break;
-                case 'Producer':
-                    if (oldInforSrc && oldInforSrc.toText) {
-                        infoDictionary.addAdditionalInfoEntry(`source-${key}`, oldInforSrc.toText());
-                    }
+                case 'producer':
+                    infoDictionary.addAdditionalInfoEntry('source-Producer', oldInfo.producer);
                     break;
                 default:
-                    if (oldInforSrc && oldInforSrc.toText) {
-                        infoDictionary[key.toLowerCase()] = oldInforSrc.toText();
-                    }
+                    infoDictionary[key] = oldInfo[key];
             }
         });
     }

--- a/tests/info.js
+++ b/tests/info.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HummusRecipe = require('../lib');
+const assert = require('chai').assert;
 
 describe('Modify', () => {
     it('Change info pdf', (done) => {
@@ -18,6 +19,13 @@ describe('Modify', () => {
             })
             .endPage()
             .endPDF(done);
+    });
+    it('Read document title', (done) => {
+        const src = path.join(__dirname, 'output/change info.pdf');
+        const recipe = new HummusRecipe(src);
+        const info = recipe.getDocumentInfo();
+        assert.equal(info.title, 'Hello World');   // This test depends on output from above.
+        recipe.endPDF(done);
     });
     it('Change info pdf', (done) => {
         const src = path.join(__dirname, 'materials/test-info.pdf');


### PR DESCRIPTION
This allows a user to get access to the document information stored in an existing PDF file, such as title, subject, etc.  A new interface has been created, called getDocumentInfo which will need to be added to documentation. No parameters are passed to it.