### PR TITLE
Interface change

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -2,30 +2,32 @@ const fs = require('fs');
 const hummus = require('hummus');
 /**
  * @name info
- * @desc Add information to pdf
+ * @desc Add new PDF information, or retrieve existing PDF information.
  * @memberof Recipe
  * @function
- * @param {Object} [options] - The options
+ * @param {Object} [options] - The options (when missing obtains existing PDF information)
  * @param {number} [options.version] - The pdf version
  * @param {string} [options.author] - The author
  * @param {string} [options.title] - The title
  * @param {string} [options.subject] - The subject
  * @param {string[]} [options.keywords] - The array of keywords
  */
-exports.info = function info(options = {}) {
-    this.toWriteInfo_ = this.toWriteInfo_ || {};
-    Object.assign(this.toWriteInfo_, options);
-    return this;
+exports.info = function info(options) {
+    let result;
+
+    if (! options) {
+        result = this._readInfo();
+        
+    } else {
+        this.toWriteInfo_ = this.toWriteInfo_ || {};
+        Object.assign(this.toWriteInfo_, options);
+        result = this;
+    }
+
+    return result;
 };
 
-/**
- * @name getDocumentInfo
- * @desc Obtain document information from existing PDF
- * @memberof Recipe
- * @function
- * @returns object containing document information, or undefined.
- */
-exports.getDocumentInfo = function _readInfo() {
+exports._readInfo = function _readInfo() {
     if (!this.isNewPDF && !this.infoDictionary) {
         const copyFrom = this.isBufferSrc ? new hummus.PDFRStreamForBuffer(this.src) : this.src;
         const copyCtx  = this.writer.createPDFCopyingContext(copyFrom);
@@ -85,7 +87,7 @@ exports.getDocumentInfo = function _readInfo() {
 
 exports._writeInfo = function _writeInfo() {
     const options = this.toWriteInfo_ || {};
-    const oldInfo = this.getDocumentInfo();
+    const oldInfo = this._readInfo();
     /*
         #41, #48
         This issue is due to the unhandled process exit from HummusJS.

--- a/tests/info.js
+++ b/tests/info.js
@@ -23,7 +23,7 @@ describe('Modify', () => {
     it('Read document title', (done) => {
         const src = path.join(__dirname, 'output/change info.pdf');
         const recipe = new HummusRecipe(src);
-        const info = recipe.getDocumentInfo();
+        const info = recipe.info();
         assert.equal(info.title, 'Hello World');   // This test depends on output from above.
         recipe.endPDF(done);
     });


### PR DESCRIPTION
I decided to use the existing 'info' interface, without parameter options to trigger the retrieval of the existing PDF information instead of the getDocumentInfo.