### PR TITLE
allow padding values of 0 and set paddingLeft

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -98,11 +98,12 @@ exports.text = function text(text = '', x, y, options = {}) {
     };
 
     textBox.padding = (Array.isArray(textBox.padding)) ? textBox.padding : [textBox.padding];
+    function findVal(...args) { return args.find((v) => v !== undefined); }
     Object.assign(textBox, {
         paddingTop: textBox.padding[0],
-        paddingRight: textBox.padding[1] || textBox.padding[0],
-        paddingBottom: textBox.padding[2] || textBox.padding[0],
-        paddingLeft: textBox.padding[2] || textBox.padding[1] || textBox.padding[0],
+        paddingRight: findVal(textBox.padding[1], textBox.padding[0]),
+        paddingBottom: findVal(textBox.padding[2], textBox.padding[0]),
+        paddingLeft: findVal(textBox.padding[3], textBox.padding[1], textBox.padding[0]),
     });
     let firstLineHeight;
     // let lastLineHeight;


### PR DESCRIPTION
HI, I think that textBox padding went a little bit sideways sometime since v1.4. I propose that something like these changes is in order so that 1) you can provide `0` as a pad right/bottom/left value and 2) you can specify a `paddingLeft` value at index 3 of the `padding` array.

- don't use logical OR to set padding right/bottom/left because 0 is a valid padding value
- use `textBox.padding[3]` (if present) as `paddingLeft`