### PR TITLE
Fix for missing text in annotation #113

### DIFF
--- a/lib/annotation.js
+++ b/lib/annotation.js
@@ -107,7 +107,7 @@ exports._annot = function _annot(subtype, args = {}, pageNumber) {
         .writeKey('Rect')
         .writeRectangleValue(position)
         .writeKey('Subj')
-        .writeLiteralStringValue(this.writer.createPDFTextString(params.subject).toBytesArray())
+        .writeLiteralStringValue(params.subject)
         .writeKey('T')
         .writeLiteralStringValue(params.title || '')
         .writeKey('M')
@@ -123,13 +123,13 @@ exports._annot = function _annot(subtype, args = {}, pageNumber) {
      */
     if (text && options.richText) {
         const richText = (text.substring(0, 4) !== '<?xml') ? contentToRC(text) : text;
-        const richTextContent = this.writer.createPDFTextString(richText).toBytesArray();
+        const richTextContent = richText;
         this.dictionaryContext
             .writeKey('RC')
             .writeLiteralStringValue(richTextContent);
     } else
     if (text) {
-        const textContent = this.writer.createPDFTextString(text).toBytesArray();
+        const textContent = text;
         this.dictionaryContext
             .writeKey('Contents')
             .writeLiteralStringValue(textContent);

--- a/tests/annotation-comment.js
+++ b/tests/annotation-comment.js
@@ -8,9 +8,14 @@ describe('Annotation: Comment', () => {
         recipe
             // 1st Page
             .createPage('letter-size')
+            .text('Click\nbelow', 298, 60)
+            .text('Except for the background rectangle exposing it, the annotation above would normally be invisible because no color option was given to it.',
+               175, 150, {textBox: {width: 280, textAlign:'center'}})
+            .rectangle(290, 90, 50, 50, {fill:'red', opacity:.2})
             .comment('Feel free to open issues to help us!', 'center', 100, {
                 title: 'First Comment',
-                flag: 'locked'
+                subject: 'Not Really Visible',
+                // flag: 'locked'
             })
             .endPage()
             .endPDF(done);
@@ -68,11 +73,11 @@ describe('Annotation: Comment', () => {
         recipe
             // 1st Page
             .createPage('letter-size')
-            .text('Trace-based Just-in-Time Type Specialization for Dynamic Languages', 'center', 'center')
-            .annot('center', 'center', 'Highlight', {
+            .text('Trace-based Just-in-Time Type Specialization for Dynamic Languages', 100, 'center')
+            .annot(100, 'center', 'Highlight', {
                 text: 'Oh~la',
                 width: 200,
-                height: 50
+                height: 14
             })
             .endPage()
             .endPDF(done);


### PR DESCRIPTION
I got rid of all references to the broken hummus.createPDFTextString function and just used the straight text reference. I updated test to help find those invisible annotations.