### PR TITLE
Fix to prevent crash #61

### DIFF
--- a/lib/appendPage.js
+++ b/lib/appendPage.js
@@ -13,8 +13,12 @@ exports.appendPage = function appendPage(pdfSrc, pages = []) {
     if (!Array.isArray(pages) && !isNaN(pages)) {
         pages = [pages];
     }
-    const pdfReader = hummus.createReader(pdfSrc);
+    // Using stream so it can be closed to release reader resource (Issue #61) 
+    const instream  = new hummus.PDFRStreamForFile(pdfSrc);
+    const pdfReader = hummus.createReader(instream);
     const pageCount = pdfReader.getPagesCount();
+    instream.close();
+
     // prevent unmatched pagenumber
     const transformPageNumber = (pageNum) => {
         pageNum = (pageNum > pageCount) ? pageCount : pageNum;


### PR DESCRIPTION
The problem was that putting appendPage opens up a reader file resource that does not get released after function is complete, so when it is called within a large loop, the program runs out of file descriptors. Using a stream to open the reader allows it to be closed and release the file descriptor.

The only thing of note is that it has been mentioned elsewhere that using a stream to read the file is slower than feeding the file path directly to createReader. That may be true, but at least now repetitive calls to appendPage no longer crash. 