### PR TITLE
Fix for #168

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -150,6 +150,7 @@ exports._resumePageRotation = function _resumePageRotation(pageNumber, context) 
     context = context || this.pageContext;
     const startX = mediaBox[0];
     const startY = mediaBox[1];
+    this.page.mediaBox = [startX, startY, width, height];
 
     switch (rotate) {
         case 90:


### PR DESCRIPTION
The page.mediaBox was not populated when editing a page causing an exception.
I am unsure if the fix is sufficient for when an actual page rotation occurs, but I don't know how to test for this to see if I can create a failure.