### PR TITLE
Fill vectors with separation color

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -113,9 +113,9 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
 
         this._drawObject(this, nx, ny, width, height, pathOptions, (ctx, xObject) => {
             ctx.gs(xObject.getGsName(pathOptions.fillGsId));
+            xObject.fill(colorModel);
 
             if (options.borderRadius) {
-                xObject.fill(colorModel);
                 drawRoundedRectangle(ctx, 0, 0, width, height, options.borderRadius);
                 ctx.f();
             } else {
@@ -139,9 +139,9 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
 
             // ... requires adjusting the internal drawing to accomodate line thickness.
             const margin = pathOptions.width;
+            xObject.stroke(colorModel);
 
             if (options.borderRadius) {
-                xObject.stroke(colorModel);
                 ctx
                     .w(pathOptions.width)
                     .d(pathOptions.dash, pathOptions.dashPhase);


### PR DESCRIPTION
Hi guys,

I've been looking for a PDF creator library that would be able to manage Separation color and it seems that you did the job. But after doing a basic test,   it seems that I had four black squares instead of my four coloured square (with separation color) : 

#### My test
```
const pdfDoc = new HummusRecipe("new", outPath, {
  colorspace: "separation"
});
pdfDoc
  .createPage("letter-size")
  .rectangle(40, 40, 51, 51, {
    fill: "%50,39,0,12",
    colorName: "TestA"
  })
  .rectangle(80, 80, 51, 51, {
    fill: "%100,0,0,100",
    colorName: "TestB"
  })
  .rectangle(120, 120, 51, 51, {
    fill: "%100,0,100,0",
    colorName: "TestC"
  })
  .rectangle(160, 160, 51, 51, {
    fill: "%100,100,0,0",
    colorName: "TestD"
  })
  .endPage()
  .endPDF(() => {
    // done
  });
```

After some reading and testing, I found out that rectangles were not filled with color except if border radius was specified. So I did the modification.

**It seems that the problem is only visible with separation color, if it's rgb or cmyk you won't see any problem.**

Do you think that can be merged ?