### PR TITLE
Fix text 'separation' colors #187

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -334,7 +334,11 @@ exports.text = function text(text = '', x, y, options = {}) {
             const addTextTraits = (ctx, options) => {
                 ctx.Tf(options.font, options.size);
                 ctx.Tc(options.charSpace);
-                Color.fill(ctx, options.colorModel);
+                if (options.colorModel.xObject) {
+                    options.colorModel.xObject.fill(options.colorModel);
+                } else {
+                    Color.fill(ctx, options.colorModel);
+                }
             };
 
             const emitText = (word, x, y, ctx) => {
@@ -442,6 +446,9 @@ exports.text = function text(text = '', x, y, options = {}) {
                     // https://github.com/galkahana/HummusJS/wiki/Use-the-pdf-drawing-operators
                     const xObject = new xObjectForm(this.writer, textBox.width, lineHeight);
                     const xObjectCtx = xObject.getContentContext();
+                    if (options.colorModel) {
+                        options.colorModel.xObject = xObject;
+                    }
 
                     xObjectCtx.q();
                     xObjectCtx.gs(xObject.getGsName(options.fillGsId)); // set graphic state (here opacity)


### PR DESCRIPTION
Text using separation colors needs Xobjects and the new addTextTraits function was not aware of this.