### PR TITLE
Fixes long text without separators in textbox #184

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -1083,7 +1083,19 @@ function makeTextObjects(self, textObject = {}, pathOptions, textBox = {}) {
             if (textBox.wrap !== 'auto') {
                 flushLine = true;
                 elideNonFittingText(textBox, newLine, word, pathOptions);
-                toWriteTextObjects[toWriteTextObjects.length - 1].text = newLine.value;
+
+                if (toWriteTextObjects.length > 0) {
+                    toWriteTextObjects[toWriteTextObjects.length - 1].text = newLine.value;
+                } else {
+                    // this is the first line in the box (no other line yet emitted) ...
+                    toWriteTextObjects.push(
+                        makeTextObject(lines, newLine, lineID, textBox,
+                            Object.assign({}, lineOpts, {
+                                lineComplete: true
+                            })
+                        )
+                    );
+                }
 
             } else {
                 // this is the auto wrap section

--- a/tests/text-centering.js
+++ b/tests/text-centering.js
@@ -10,6 +10,15 @@ describe('Text - Centering', () => {
         recipe
             .createPage('letter-size')
             .circle(30,220,2,{stroke:'red'})
+            .text('NO_Space_Breaks_And_Wrap=false_gives_Ellipsis',350, 27, {
+                color: 'red',
+                size: 10,
+                font: 'arial',
+                textBox: {
+                  width: 215,
+                  wrap: false,
+                }
+            })
             .text('Crusty', 30, 220, {
                 color: '#000000',
                 font: 'Arial',
@@ -79,7 +88,6 @@ describe('Text - Centering', () => {
 
         let fs = 20;
         recipe
-            .text('<-- Note, using padding of 2\n      puts marker dots inside fill.', 340, 455)
             .text('<-- Text with line height applied\n            (1.16% font size).', 340, 490)
             .text('A\nAAA\nOOO\nVVV\n|', 30, 400, {
                 color: '#000000',


### PR DESCRIPTION
Needed to put a guard in place when the long text string appears as the first and only text and the wrap is set to false (effectivley setting the wrap to ellipsis)